### PR TITLE
fix(hebrew): align keys with physical Hebrew keyboard

### DIFF
--- a/build/layouts/hebrew.js
+++ b/build/layouts/hebrew.js
@@ -5,10 +5,10 @@
 export default {
     layout: {
         default: [
-            "\u05e5 1 2 3 4 5 6 7 8 9 0 - = {bksp}",
-            "{tab} \u05e3 \u05df \u05e7 \u05e8 \u05d0 \u05d8 \u05d5 \u05ea \u05dd \u05e4 ] [ \\",
-            "{lock} \u05e9 \u05d3 \u05d2 \u05db \u05e2 \u05d9 \u05d7 \u05dc \u05da : ' {enter}",
-            "{shift} \u05d6 \u05e1 \u05d1 \u05d4 \u05e0 \u05de \u05e6 , . / {shift}",
+            " 1 2 3 4 5 6 7 8 9 0 - = {bksp}",
+            "{tab} / \' \u05e7 \u05e8 \u05d0 \u05d8 \u05d5 \u05df \u05dd \u05e4 ] [ :",
+            "{lock} \u05e9 \u05d3 \u05d2 \u05db \u05e2 \u05d9 \u05d7 \u05dc \u05da \u05e3 , {enter}",
+            "{shift} \u05d6 \u05e1 \u05d1 \u05d4 \u05e0 \u05de \u05e6 \u05ea \u05e5 . {shift}",
             ".com @ {space}",
         ],
         shift: [

--- a/src/lib/layouts/hebrew.ts
+++ b/src/lib/layouts/hebrew.ts
@@ -7,11 +7,11 @@ import { LayoutItem } from "../interfaces";
 export default <LayoutItem>{
   layout: {
     default: [
-      "\u05e5 1 2 3 4 5 6 7 8 9 0 - = {bksp}",
-      "{tab} \u05e3 \u05df \u05e7 \u05e8 \u05d0 \u05d8 \u05d5 \u05ea \u05dd \u05e4 ] [ \\",
-      "{lock} \u05e9 \u05d3 \u05d2 \u05db \u05e2 \u05d9 \u05d7 \u05dc \u05da : ' {enter}",
-      "{shift} \u05d6 \u05e1 \u05d1 \u05d4 \u05e0 \u05de \u05e6 , . / {shift}",
-      ".com @ {space}",
+      " 1 2 3 4 5 6 7 8 9 0 - = {bksp}",
+      "{tab} / \' \u05e7 \u05e8 \u05d0 \u05d8 \u05d5 \u05df \u05dd \u05e4 ] [ :",
+      "{lock} \u05e9 \u05d3 \u05d2 \u05db \u05e2 \u05d9 \u05d7 \u05dc \u05da \u05e3 , {enter}",
+      "{shift} \u05d6 \u05e1 \u05d1 \u05d4 \u05e0 \u05de \u05e6 \u05ea \u05e5 . {shift}",
+      ".com @ {space}"
     ],
     shift: [
       "~ ! @ # $ % ^ & * ( ) _ + {bksp}",


### PR DESCRIPTION
## Description

Aligning the keys by the physical Hebrew keyboard.

These are the changes (the '+' signed didn't change)

![image](https://user-images.githubusercontent.com/1301334/113716571-6a535e80-96f3-11eb-8032-4d800f859b11.png)


## Checks

- [X] Tests ( `npm run test` ) are passing
