### PR TITLE
Add Keyboard Layout for Ndebe Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To fully customize your virtual keyboard, check out the main [simple-keyboard re
 - [Korean](https://hodgef.com/simple-keyboard/demos/?d=korean)
 - [Kurdish](https://hodgef.com/simple-keyboard/demos/?d=kurdish) - by [Goran Gharib](https://github.com/GoRaN909)
 - [Malayalam](https://hodgef.com/simple-keyboard/demos/?d=malayalam) - by [Sajad J](https://github.com/4gon)
+- [Ndebe](https://hodgef.com/simple-keyboard/demos/?d=ndebe) - by [Lotanna Igwe-Odunze](https://github.com/odunze) for [The Ndebe Project](https://github.com/ndebeproject)
 - [Nigerian](https://hodgef.com/simple-keyboard/demos/?d=nigerian) - by [Benson Muite](https://github.com/bkmgit)
 - [N'ko](https://hodgef.com/simple-keyboard/demos/?d=nko) - by [kjitteh](https://github.com/kjitteh)
 - [Norwegian](https://hodgef.com/simple-keyboard/demos/?d=norwegian) - by [Prakriti Tiwari](https://github.com/prakriti89)

--- a/src/lib/components/Layouts.ts
+++ b/src/lib/components/Layouts.ts
@@ -25,6 +25,7 @@ import kannada from "../layouts/kannada";
 import korean from "../layouts/korean";
 import kurdish from "../layouts/kurdish";
 import malayalam from "../layouts/malayalam";
+import ndebe from "../layouts/ndebe";
 import nigerian from "../layouts/nigerian";
 import nko from "../layouts/nko";
 import norwegian from "../layouts/norwegian";
@@ -71,6 +72,7 @@ class SimpleKeyboardLayouts {
     korean,
     kurdish,
     malayalam,
+    ndebe,
     nigerian,
     nko,
     norwegian,

--- a/src/lib/layouts/ndebe.ts
+++ b/src/lib/layouts/ndebe.ts
@@ -1,0 +1,31 @@
+import { LayoutItem } from "../interfaces";
+
+/**
+ * Layout: Ndebe
+ * Source: Lotanna Igwe-Odunze (https://github.com/odunze) for The Ndebe Project (https://github.com/ndebeproject)
+ */
+ export default <LayoutItem>{
+   layout: {
+     default: [
+       "` \e101 \e102 \e103 \e104 \e105 \e106 \e107 \e108 \e109 \e100 - = {bksp}",
+       "{tab} \e25A \e300 \e254 \e351 \e350 \e301 \e266 \e354 \e263 \e26C [ ] \\",
+       "{lock} \e257 \e302 \e353 \e352 \e303 \e251 \e355 \e304 \e269 ; ' {enter}",
+       "{shift} \e356 \e25D \e305 \e260 b n m , . / {shift}",
+       ".com @ {space}",
+     ],
+     shift: [
+       "~ ! @ # $ % ^ & * ( ) _ + {bksp}",
+       "{tab} \e259 W \e253 R T Y \e265 I \e262 \e26B { } |",
+       '{lock} \e256 S D F G \e250 J K \e268 : " {enter}',
+       "{shift} Z \e25C C \e25F B N M < > ? {shift}",
+       ".com @ {space}",
+     ],
+     alt: [
+       "~ \e10B \e10C \e10D \e10E \e10F \e110 \e111 \e112 \e113 \e10A _ + {bksp}",
+       "{tab} \e25B W \e255 R T Y \e267 I \e264 \e26D { } |",
+       '{lock} \e258 S D F G \e252 J K \e26A : " {enter}',
+       "{shift} Z \e25E C \e261 B N M < > ? {shift}",
+       ".com @ {space}",
+     ],
+   },
+ };

--- a/src/lib/layouts/ndebe.ts
+++ b/src/lib/layouts/ndebe.ts
@@ -7,18 +7,18 @@ import { LayoutItem } from "../interfaces";
  export default <LayoutItem>{
    layout: {
      default: [
-       "` \uE101 \uE102 \uE103 \uE104 \uE105 \uE106 \uE107 \uE108 \uE109 \uE100 - = {bksp}",
-       "{tab} \uE25A \uE300 \uE254 \uE351 \uE350 \uE301 \uE266 \uE354 \uE263 \uE255 [ ] \\",
-       "{lock} \uE257 \uE302 \uE353 \uE352 \uE303 \uE251 \uE355 \uE304 \uE269 ; ' {enter}",
-       "{shift} \uE356 \uE25D \uE305 \uE260 \uE26B \uE26C \uE26D , . / {shift}",
-       ".com @ {space}",
-     ],
-     shift: [
-       "~ ! @ # $ % ^ & * ( ) _ + {bksp}",
-       "{tab} \uE259 \uE10B \uE253 \uE10C \uE10D \uE10E \uE265 \uE10F \uE262 \uE25B { } |",
-       '\uE10A \uE256 \uE110 \uE111 \uE112 \uE113 \uE250 \uE267 \uE264 \uE268 : " {enter}',
-       "{shift} \uE258 \uE25C \uE252 \uE25F \uE26A \uE25E \uE261 < > ? {shift}",
-       ".com @ {space}",
-     ]
+      "` \uE101 \uE102 \uE103 \uE104 \uE105 \uE106 \uE107 \uE108 \uE109 \uE100 - = {bksp}",
+      "{tab} \uE259 \uE300 \uE253 \uE351 \uE350 \uE301 \uE265 \uE354 \uE262 \uE26B [ ] \\",
+      "{lock} \uE256 \uE302 \uE353 \uE352 \uE303 \uE250 \uE355 \uE304 \uE268 ; · {enter}",
+      "{shift} \uE356 \uE25C \uE305 \uE25F \uE254 \uE26C \uE26D , . / {shift}",
+      ".com @ {space}",
+    ],
+    shift: [
+      "~ ! @ # $ % ^ & * ( ) _ + {bksp}",
+      "{tab} \uE25B \uE10B \uE255 \uE10C \uE10D \uE10E \uE267 \uE10F \uE264 \uE25A { } |",
+      '\uE10A \uE258 \uE110 \uE111 \uE112 \uE113 \uE252 \uE266 \uE263 \uE26A : " {enter}',
+      "{shift} \uE257 \uE25E \uE251 \uE261 \uE269 \uE25D \uE260 < > ? {shift}",
+      ".com @ {space}",
+    ]
    },
  };

--- a/src/lib/layouts/ndebe.ts
+++ b/src/lib/layouts/ndebe.ts
@@ -7,17 +7,17 @@ import { LayoutItem } from "../interfaces";
  export default <LayoutItem>{
    layout: {
      default: [
-       "` \e101 \e102 \e103 \e104 \e105 \e106 \e107 \e108 \e109 \e100 - = {bksp}",
-       "{tab} \e25A \e300 \e254 \e351 \e350 \e301 \e266 \e354 \e263 \e255 [ ] \\",
-       "{lock} \e257 \e302 \e353 \e352 \e303 \e251 \e355 \e304 \e269 ; ' {enter}",
-       "{shift} \e356 \e25D \e305 \e260 \e26B \e26C \e26D , . / {shift}",
+       "` \uE101 \uE102 \uE103 \uE104 \uE105 \uE106 \uE107 \uE108 \uE109 \uE100 - = {bksp}",
+       "{tab} \uE25A \uE300 \uE254 \uE351 \uE350 \uE301 \uE266 \uE354 \uE263 \uE255 [ ] \\",
+       "{lock} \uE257 \uE302 \uE353 \uE352 \uE303 \uE251 \uE355 \uE304 \uE269 ; ' {enter}",
+       "{shift} \uE356 \uE25D \uE305 \uE260 \uE26B \uE26C \uE26D , . / {shift}",
        ".com @ {space}",
      ],
      shift: [
        "~ ! @ # $ % ^ & * ( ) _ + {bksp}",
-       "{tab} \e259 \e10B \e253 \e10C \e10D \e10E \e265 \e10F \e262 \e25B { } |",
-       '\e10A \e256 \e110 \e111 \e112 \e113 \e250 \e267 \e264 \e268 : " {enter}',
-       "{shift} \e258 \e25C \e252 \e25F \e26A \e25E \e261 < > ? {shift}",
+       "{tab} \uE259 \uE10B \uE253 \uE10C \uE10D \uE10E \uE265 \uE10F \uE262 \uE25B { } |",
+       '\uE10A \uE256 \uE110 \uE111 \uE112 \uE113 \uE250 \uE267 \uE264 \uE268 : " {enter}',
+       "{shift} \uE258 \uE25C \uE252 \uE25F \uE26A \uE25E \uE261 < > ? {shift}",
        ".com @ {space}",
      ]
    },

--- a/src/lib/layouts/ndebe.ts
+++ b/src/lib/layouts/ndebe.ts
@@ -8,23 +8,16 @@ import { LayoutItem } from "../interfaces";
    layout: {
      default: [
        "` \e101 \e102 \e103 \e104 \e105 \e106 \e107 \e108 \e109 \e100 - = {bksp}",
-       "{tab} \e25A \e300 \e254 \e351 \e350 \e301 \e266 \e354 \e263 \e26C [ ] \\",
+       "{tab} \e25A \e300 \e254 \e351 \e350 \e301 \e266 \e354 \e263 \e255 [ ] \\",
        "{lock} \e257 \e302 \e353 \e352 \e303 \e251 \e355 \e304 \e269 ; ' {enter}",
-       "{shift} \e356 \e25D \e305 \e260 b n m , . / {shift}",
+       "{shift} \e356 \e25D \e305 \e260 \e26B \e26C \e26D , . / {shift}",
        ".com @ {space}",
      ],
      shift: [
        "~ ! @ # $ % ^ & * ( ) _ + {bksp}",
-       "{tab} \e259 W \e253 R T Y \e265 I \e262 \e26B { } |",
-       '{lock} \e256 S D F G \e250 J K \e268 : " {enter}',
-       "{shift} Z \e25C C \e25F B N M < > ? {shift}",
-       ".com @ {space}",
-     ],
-     alt: [
-       "~ \e10B \e10C \e10D \e10E \e10F \e110 \e111 \e112 \e113 \e10A _ + {bksp}",
-       "{tab} \e25B W \e255 R T Y \e267 I \e264 \e26D { } |",
-       '{lock} \e258 S D F G \e252 J K \e26A : " {enter}',
-       "{shift} Z \e25E C \e261 B N M < > ? {shift}",
+       "{tab} \e259 \e10B \e253 \e10C \e10D \e10E \e265 \e10F \e262 \e25B { } |",
+       '\e10A \e256 \e110 \e111 \e112 \e113 \e250 \e267 \e264 \e268 : " {enter}',
+       "{shift} \e258 \e25C \e252 \e25F \e26A \e25E \e261 < > ? {shift}",
        ".com @ {space}",
      ]
    },

--- a/src/lib/layouts/ndebe.ts
+++ b/src/lib/layouts/ndebe.ts
@@ -26,6 +26,6 @@ import { LayoutItem } from "../interfaces";
        '{lock} \e258 S D F G \e252 J K \e26A : " {enter}',
        "{shift} Z \e25E C \e261 B N M < > ? {shift}",
        ".com @ {space}",
-     ],
+     ]
    },
  };


### PR DESCRIPTION
## Description
Creates `ndebe.ts` and adds Ndebe layout information to `Layouts.ts` and `README.md` to add keyboard support for Ndebe Script ( used to write Igbo language )

https://ndebe.org

## Checks

- [x] Tests ( `npm run test` ) are passing
