### PR TITLE
Add type module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.314",
   "description": "Layouts module for simple-keyboard",
   "main": "build/index.js",
+  "type": "module",
   "scripts": {
     "start": "webpack serve --config webpack.config.demo.js",
     "build": "webpack && tsc && npm run buildLayouts",


### PR DESCRIPTION
## Description

Build an application with Vite results in this error: 

`SyntaxError: Unexpected token 'export'`

By adding "type":"module" in the package.json the build runs successfully.
