### PR TITLE
Add jawi layout support

### DIFF
--- a/src/lib/components/Layouts.ts
+++ b/src/lib/components/Layouts.ts
@@ -21,6 +21,7 @@ import hindi from "../layouts/hindi";
 import hungarian from "../layouts/hungarian";
 import italian from "../layouts/italian";
 import japanese from "../layouts/japanese";
+import jawi from "../layouts/jawi";
 import kannada from "../layouts/kannada";
 import korean from "../layouts/korean";
 import kurdish from "../layouts/kurdish";
@@ -67,6 +68,7 @@ class SimpleKeyboardLayouts {
     hungarian,
     italian,
     japanese,
+    jawi,
     kannada,
     korean,
     kurdish,

--- a/src/lib/layouts/jawi.ts
+++ b/src/lib/layouts/jawi.ts
@@ -1,0 +1,23 @@
+import { LayoutItem } from "../interfaces";
+
+/**
+ * Layout: Jawi
+ */
+export default <LayoutItem>{
+  layout: {
+    default: [
+      "\u0630 1 2 3 4 5 6 7 8 9 0 - = {bksp}",
+      "{tab} \u0636 \u0635 \u062B \u0642 \u0641 \u063A \u0639 \u0647 \u062E \u062D \u062C \u062F \\",
+      "{lock} \u0634 \u0633 \u064A \u0628 \u0644 \u0627 \u062A \u0646 \u0645 \u0643 \u0637 {enter}",
+      "{shift} \u0626 \u0621 \u0624 \u0631 \u0644\u0627 \u0649 \u0629 \u0648 \u0632 \u0638 {shift}",
+      ".com @ {space}",
+    ],
+    shift: [
+      "\u0651 ! @ # $ % ^ & * ) ( _ + {bksp}",
+      "{tab} \u0762 \u06cf \u06bd \u06a4 \u0644\u0625 \u0625 \u2018 \u00F7 \u00D7 \u061B < > |",
+      '{lock} \u06a0 \u0686 ] [ \u0644\u0623 \u0623 \u0640 \u060C / : " {enter}',
+      "{shift} ~ \u0652 } { \u0644\u0622 \u0622 \u2019 , . \u061F {shift}",
+      ".com @ {space}",
+    ],
+  },
+};


### PR DESCRIPTION
## Description

Add Jawi layout support, we can use this URL  for reference https://en.wikipedia.org/wiki/Jawi_keyboard

### Preview
Tested on CodeSandbox https://codesandbox.io/s/zealous-hellman-m1s66?file=/src/index.js

#### Default
![image](https://user-images.githubusercontent.com/2532862/234714224-5d728126-2db4-4bdb-b852-23f9dea0f007.png)

#### Shift
![image](https://user-images.githubusercontent.com/2532862/234714259-7b83ce37-8b9e-45b4-a469-927c5c0b8257.png)


## Checks

- [ ] Tests ( `npm run test` ) are passing
