### PR TITLE
Add "type": "module" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.112",
   "description": "Layouts module for simple-keyboard",
   "main": "build/index.js",
+  "type": "module",
   "scripts": {
     "start": "webpack serve --config webpack.config.demo.js",
     "build": "webpack && npm run build-esm && tsc && npm run buildLayouts",


### PR DESCRIPTION
## Description

This enables dynamic imports in a node context.

Without the "type": "module" declaration, nodejs tries to import this package as a CommonJS module when using the dynamic `import()`, resulting in the error "Unexpected token 'export'".

Fixes #2303

## Checks

- [x] I have read and followed the [Contributing Guidelines](https://github.com/simple-keyboard/simple-keyboard-layouts/blob/master/CONTRIBUTING.md).
